### PR TITLE
Skills and contact views design

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,6 @@
 export default defineAppConfig({
   nuxtIcon: {
     size: '20px',
-    class: 'mr-1 text-slate-900 dark:text-slate-50',
+    class: 'text-slate-900 dark:text-slate-50',
   },
 })

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -5,7 +5,7 @@
       class="!mr-0 h-16 w-16 sm:h-32 sm:w-32 lg:h-40 lg:w-40"
       :class="iconClasses"
     />
-    <div class="mt-2 text-center">{{ title }}</div>
+    <div class="mt-2 text-center sm:text-xl">{{ title }}</div>
   </div>
 </template>
 <script setup lang="ts">

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -1,8 +1,8 @@
 <template>
-  <div>
+  <div class="flex flex-col items-center">
     <Icon
       :name="icon"
-      class="!mr-0 h-16 w-16 sm:h-28 sm:w-28"
+      class="!mr-0 h-16 w-16 sm:h-32 sm:w-32 lg:h-40 lg:w-40"
       :class="iconClasses"
     />
     <div class="mt-2 text-center">{{ title }}</div>

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -2,10 +2,12 @@
   <div class="flex flex-col items-center">
     <Icon
       :name="icon"
-      class="!mr-0 h-16 w-16 sm:h-32 sm:w-32 lg:h-40 lg:w-40"
+      class="!mr-0 h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
       :class="iconClasses"
     />
-    <div class="mt-2 text-center sm:text-xl">{{ title }}</div>
+    <div class="mt-2 text-center text-lg font-medium sm:text-2xl">
+      {{ title }}
+    </div>
   </div>
 </template>
 <script setup lang="ts">

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <Icon
+      :name="icon"
+      class="!mr-0 h-16 w-16 sm:h-28 sm:w-28"
+      :class="iconClasses"
+    />
+    <div class="mt-2 text-center">{{ title }}</div>
+  </div>
+</template>
+<script setup lang="ts">
+interface Props {
+  icon: string
+  title: string
+  iconClasses?: string
+}
+defineProps<Props>()
+</script>

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -2,6 +2,7 @@
   <div class="flex flex-col items-center">
     <Icon
       :name="icon"
+      :color="color"
       class="h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
       :class="iconClasses"
     />
@@ -15,6 +16,7 @@ interface Props {
   icon: string
   title: string
   iconClasses?: string
+  color?: string
 }
 defineProps<Props>()
 </script>

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col items-center">
     <Icon
       :name="icon"
-      class="!mr-0 h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
+      class="h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
       :class="iconClasses"
     />
     <div class="mt-2 text-center text-lg font-medium sm:text-2xl">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,7 @@
     >
       <div class="flex items-center gap-4 md:gap-8 lg:gap-10">
         <NuxtLink class="nav-item" to="/" aria-label="home page"
-          ><Icon name="heroicons-outline:home" class="!mr-0 h-6 w-6"
+          ><Icon name="heroicons-outline:home" class="h-6 w-6"
         /></NuxtLink>
         <NuxtLink
           class="nav-item"

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -7,15 +7,6 @@
     </h1>
     <div>
       <div class="flex items-center">
-        <Icon name="mdi:github" class="h-6 w-6" />
-        <a
-          href="https://github.com/jalridley"
-          class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-        >
-          Github</a
-        >
-      </div>
-      <div class="flex items-center">
         <Icon name="mdi:linkedin" class="h-6 w-6" />
         <a
           href="https://www.linkedin.com/in/jal-ridley"
@@ -32,6 +23,17 @@
           >Email</a
         >
       </div>
+    </div>
+    <div
+      class="grid grid-cols-3 gap-5 rounded-xl sm:gap-10 md:grid-cols-4 lg:gap-16"
+    >
+      <NuxtLink
+        to="https://github.com/jalridley"
+        aria-label="Go to Jal's Github"
+        class="hover:text-yellow-500"
+      >
+        <CardIcon icon="mdi:github" title="Github" />
+      </NuxtLink>
     </div>
   </section>
 </template>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -7,15 +7,6 @@
     </h1>
     <div>
       <div class="flex items-center">
-        <Icon name="mdi:linkedin" class="h-6 w-6" />
-        <a
-          href="https://www.linkedin.com/in/jal-ridley"
-          class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-        >
-          LinkedIn</a
-        >
-      </div>
-      <div class="flex items-center">
         <Icon name="heroicons:envelope" />
         <a
           href="mailto:ridleyjal@gmail.com"
@@ -29,10 +20,26 @@
     >
       <NuxtLink
         to="https://github.com/jalridley"
-        aria-label="Go to Jal's Github"
+        target="_blank"
+        aria-label="Go to Jal's Github page"
         class="hover:text-yellow-500"
       >
-        <CardIcon icon="mdi:github" title="Github" />
+        <CardIcon icon="skill-icons:github-dark" title="Github" />
+        <!-- <CardIcon icon="skill-icons:github-light" title="Github" /> -->
+      </NuxtLink>
+      <NuxtLink
+        to="https://www.linkedin.com/in/jal-ridley"
+        target="_blank"
+        aria-label="Go to Jal's LinkedIn profile"
+        class="hover:text-yellow-500"
+      >
+        <CardIcon icon="simple-icons:linkedin" title="LinkedIn" />
+        <!-- dark mode -->
+        <!-- <CardIcon
+          icon="simple-icons:linkedin"
+          title="LinkedIn"
+          color="#64748b"
+        /> -->
       </NuxtLink>
     </div>
   </section>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -5,27 +5,14 @@
     >
       Contact.
     </h1>
-    <div>
-      <div class="flex items-center">
-        <Icon name="heroicons:envelope" />
-        <a
-          href="mailto:ridleyjal@gmail.com"
-          class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-          >Email</a
-        >
-      </div>
-    </div>
-    <div
-      class="grid grid-cols-3 gap-5 rounded-xl sm:gap-10 md:grid-cols-4 lg:gap-16"
-    >
+    <div class="gap-5 sm:gap-10 md:flex md:justify-center lg:gap-16">
       <NuxtLink
         to="https://github.com/jalridley"
         target="_blank"
         aria-label="Go to Jal's Github page"
         class="hover:text-yellow-500"
       >
-        <CardIcon icon="skill-icons:github-dark" title="Github" />
-        <!-- <CardIcon icon="skill-icons:github-light" title="Github" /> -->
+        <CardIcon icon="mdi:github" title="Github" />
       </NuxtLink>
       <NuxtLink
         to="https://www.linkedin.com/in/jal-ridley"
@@ -33,13 +20,15 @@
         aria-label="Go to Jal's LinkedIn profile"
         class="hover:text-yellow-500"
       >
-        <CardIcon icon="simple-icons:linkedin" title="LinkedIn" />
-        <!-- dark mode -->
-        <!-- <CardIcon
-          icon="simple-icons:linkedin"
-          title="LinkedIn"
-          color="#64748b"
-        /> -->
+        <CardIcon icon="mdi:linkedin" title="LinkedIn" />
+      </NuxtLink>
+      <NuxtLink
+        to="mailto:ridleyjal@gmail.com"
+        target="_blank"
+        aria-label="Email Jal"
+        class="hover:text-yellow-500"
+      >
+        <CardIcon icon="mdi:email-arrow-right" title="Email" />
       </NuxtLink>
     </div>
   </section>

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -6,7 +6,7 @@
       Skills.
     </h1>
     <div
-      class="lg:grid-cols-4lg:gap-16 grid grid-cols-3 gap-5 rounded-xl p-8 shadow-3xl sm:gap-10 md:grid-cols-4 md:p-16"
+      class="grid grid-cols-3 gap-5 rounded-xl sm:gap-10 md:grid-cols-4 lg:gap-16"
     >
       <CardIcon icon="skill-icons:javascript" title="Javascript" />
       <!-- <CardIcon icon="skill-icons:vuejs-light" title="Vue.js" /> -->

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -5,58 +5,42 @@
     >
       Skills.
     </h1>
-    <ul class="mb-5">
-      <li class="flex">
-        <Icon name="skill-icons:javascript" />
-        Javascript
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:vuejs-light" /><Icon
-          name="skill-icons:vuejs-dark"
-        />Vue.js
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:nuxtjs-dark" /><Icon
-          name="skill-icons:nuxtjs-light"
-        />Nuxt
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:pinia-dark" /><Icon
-          name="skill-icons:pinia-light"
-        />Pinia
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:tailwindcss-dark" /><Icon
-          name="skill-icons:tailwindcss-light"
-        />TailwindCSS
-      </li>
-      <li class="flex"><Icon name="skill-icons:typescript" />Typescript</li>
-      <li class="flex"><Icon name="skill-icons:html" />HTML</li>
-      <li class="flex"><Icon name="skill-icons:css" />CSS</li>
-      <li class="flex"><Icon name="skill-icons:sass" />SASS</li>
-      <li class="flex">
-        <Icon
-          name="vscode-icons:file-type-storybook"
-          class="rounded-md bg-[#f4f2ed] p-0.5"
-        />Storybook
-      </li>
-      <li class="flex"><Icon name="skill-icons:cypress-light" />Cypress</li>
-      <li class="flex">
-        <Icon name="skill-icons:vitest-dark" /><Icon
-          name="skill-icons:vitest-light"
-        />Vitest
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:git" /><Icon
-          name="skill-icons:github-dark"
-        /><Icon name="skill-icons:github-light" />Git/Github
-      </li>
-      <li class="flex">
-        <Icon name="skill-icons:figma-dark" /><Icon
-          name="skill-icons:figma-light"
-        />Figma
-      </li>
-    </ul>
+    <div
+      class="mb-5 flex flex-wrap justify-center gap-5 rounded-xl p-5 shadow-3xl sm:gap-10 md:p-16 lg:gap-16"
+    >
+      <CardIcon icon="skill-icons:javascript" title="Javascript" />
+      <!-- <CardIcon icon="skill-icons:vuejs-light" title="Vue.js" /> -->
+      <CardIcon icon="skill-icons:vuejs-dark" title="Vue.js" />
+      <!-- <CardIcon icon="skill-icons:nuxtjs-light" title="Nuxt" /> -->
+      <CardIcon icon="skill-icons:nuxtjs-dark" title="Nuxt" />
+      <!-- <CardIcon icon="skill-icons:pinia-light" title="Pinia" /> -->
+      <CardIcon icon="skill-icons:pinia-dark" title="Pinia" />
+      <!-- <CardIcon icon="skill-icons:tailwindcss-light" title="TailwindCSS" /> -->
+      <CardIcon icon="skill-icons:tailwindcss-dark" title="TailwindCSS" />
+      <CardIcon icon="skill-icons:typescript" title="Typescript" />
+      <CardIcon icon="skill-icons:html" title="HTML" />
+      <CardIcon icon="skill-icons:css" title="CSS" />
+      <CardIcon icon="skill-icons:sass" title="SASS" />
+      <CardIcon
+        icon="vscode-icons:file-type-storybook"
+        title="Storybook"
+        icon-classes="rounded-2xl sm:rounded-3xl bg-[#242938] p-0.5"
+      />
+      <!-- <CardIcon
+        icon="vscode-icons:file-type-storybook"
+        title="Storybook"
+        icon-classes="rounded-2xl sm:rounded-3xl bg-[#f4f2ed] p-0.5"
+      /> -->
+      <!-- <CardIcon icon="skill-icons:cypress-light" title="Cypress" /> -->
+      <CardIcon icon="skill-icons:cypress-dark" title="Cypress" />
+      <!-- <CardIcon icon="skill-icons:vitest-light" title="Vitest" /> -->
+      <CardIcon icon="skill-icons:vitest-dark" title="Vitest" />
+      <CardIcon icon="skill-icons:git" title="Git" />
+      <!-- <CardIcon icon="skill-icons:github-light" title="Github" /> -->
+      <CardIcon icon="skill-icons:github-dark" title="Github" />
+      <!-- <CardIcon icon="skill-icons:figma-light" title="Figma" /> -->
+      <CardIcon icon="skill-icons:figma-dark" title="Figma" />
+    </div>
   </section>
 </template>
 <script setup lang="ts">

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -5,9 +5,7 @@
     >
       Skills.
     </h1>
-    <div
-      class="grid grid-cols-3 gap-5 rounded-xl sm:gap-10 md:grid-cols-4 lg:gap-16"
-    >
+    <div class="grid grid-cols-3 gap-5 sm:gap-10 md:grid-cols-4 lg:gap-16">
       <CardIcon icon="skill-icons:javascript" title="Javascript" />
       <!-- <CardIcon icon="skill-icons:vuejs-light" title="Vue.js" /> -->
       <CardIcon icon="skill-icons:vuejs-dark" title="Vue.js" />

--- a/pages/skills.vue
+++ b/pages/skills.vue
@@ -6,7 +6,7 @@
       Skills.
     </h1>
     <div
-      class="mb-5 flex flex-wrap justify-center gap-5 rounded-xl p-5 shadow-3xl sm:gap-10 md:p-16 lg:gap-16"
+      class="lg:grid-cols-4lg:gap-16 grid grid-cols-3 gap-5 rounded-xl p-8 shadow-3xl sm:gap-10 md:grid-cols-4 md:p-16"
     >
       <CardIcon icon="skill-icons:javascript" title="Javascript" />
       <!-- <CardIcon icon="skill-icons:vuejs-light" title="Vue.js" /> -->


### PR DESCRIPTION
closes #87 
closes #88 

Created a `CardIcon` component for icon with a title. Designed the skills page in a grid and all is responsive. Contacts are links with yellow hover. Removed the `mr-1` from the icon default in app config because the only icons requiring it are in the `journey` view. 

# Skills:
<img width="1109" alt="Screenshot 2024-03-09 at 20 04 34" src="https://github.com/jalridley/portfolio/assets/72085091/badc1b80-2e74-406f-8f42-f8479a6a9a52">

# Contact:
<img width="1075" alt="Screenshot 2024-03-09 at 20 04 17" src="https://github.com/jalridley/portfolio/assets/72085091/3a062614-7b2e-4796-8a76-25b98142889c">

# Contact Links on Hover:
<img width="1101" alt="Screenshot 2024-03-09 at 20 05 38" src="https://github.com/jalridley/portfolio/assets/72085091/4436cb1e-7f4c-4415-8b34-7136f5e74376">
