### PR TITLE
Journey view design

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -5,7 +5,7 @@
     </div>
 
     <div class="border-t p-5">
-      <h2 class="font-besley text-2xl font-bold md:text-3xl">
+      <h2 class="font-besley text-xl font-bold md:text-3xl">
         {{ header }}
       </h2>
       <p class="pt-3">

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -5,7 +5,7 @@
     </div>
 
     <div class="border-t p-5">
-      <h2 class="font-besley text-xl font-bold md:text-3xl">
+      <h2 class="font-besley text-xl font-bold capitalize md:text-3xl">
         {{ header }}
       </h2>
       <p class="pt-3">

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -5,9 +5,9 @@
     </div>
 
     <div class="border-t p-5">
-      <h1 class="font-besley text-xl font-bold uppercase">
+      <h2 class="font-besley text-2xl font-bold md:text-3xl">
         {{ header }}
-      </h1>
+      </h2>
       <p class="pt-3">
         <slot name="text" />
       </p>

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -6,7 +6,7 @@
       class="h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
       :class="iconClasses"
     />
-    <div class="mt-2 text-center text-lg font-medium sm:text-2xl">
+    <div class="mt-2 text-center font-medium sm:text-2xl">
       {{ title }}
     </div>
   </div>

--- a/components/CardIcon.vue
+++ b/components/CardIcon.vue
@@ -6,7 +6,7 @@
       class="h-24 w-24 sm:h-32 sm:w-32 lg:h-48 lg:w-48"
       :class="iconClasses"
     />
-    <div class="mt-2 text-center font-medium sm:text-2xl">
+    <div class="mt-2 text-center font-medium capitalize sm:text-2xl">
       {{ title }}
     </div>
   </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -34,7 +34,7 @@
         <!-- <Icon name="heroicons:moon" class="mr-0" /> -->
       </span>
     </nav>
-    <main class="flex grow flex-col px-4 text-lg lg:px-0">
+    <main class="mb-5 flex grow flex-col px-4 text-lg lg:px-0">
       <slot />
     </main>
     <footer class="flex justify-center bg-white p-2 dark:bg-slate-950">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -34,7 +34,7 @@
         <!-- <Icon name="heroicons:moon" class="mr-0" /> -->
       </span>
     </nav>
-    <main class="flex grow flex-col px-4 lg:px-0">
+    <main class="flex grow flex-col px-4 text-lg lg:px-0">
       <slot />
     </main>
     <footer class="flex justify-center bg-white p-2 dark:bg-slate-950">

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -7,18 +7,18 @@
     </h1>
     <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
       <Icon name="mdi:amplifier" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
-      Musician Gone Web Dev:
+      Musician Gone Web Dev
     </h2>
-    <p class="mb-5">
+    <p class="mb-5 md:mb-8">
       I moved from Toronto to Berlin to further my music and event planning
       career, and after twisting, turning, growing and evolving, I am now a
       Front End Developer.
     </p>
     <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
       <Icon name="heroicons:fire-16-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
-      New Rock:
+      New Rock
     </h2>
-    <p class="mb-5">
+    <p class="mb-5 md:mb-8">
       Using my indoor time during the pandemic, I began teaching myself
       programming as a hobby and quickly discovered it gave me a passion similar
       to writing music. I was hooked. Throwing myself head first in the pursuit
@@ -38,9 +38,9 @@
     </p>
     <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
       <Icon name="heroicons:bolt-20-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
-      Hard Rock:
+      Hard Rock
     </h2>
-    <p class="mb-5">
+    <p class="mb-5 md:mb-8">
       I’ve worked with Vue.js, Nuxt, Tailwind CSS, Typescript, CSS/HTML, Cypress
       e2e testing, unit tests with Vitest, Docker containers, GitHub Actions, UI
       wireframe and custom icon design in Figma, responsive design, UX
@@ -50,9 +50,9 @@
     </p>
     <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
       <Icon name="ph:feather-fill" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
-      Soft Rock:
+      Soft Rock
     </h2>
-    <p class="mb-5">
+    <p class="mb-5 md:mb-8">
       I carry with me the skills I have learned along the way from my life
       experiences before becoming a developer - problem solving, conflict
       management, clear communication, the ability to work solo, with a team,
@@ -64,9 +64,9 @@
         name="heroicons:rocket-launch-16-solid"
         class="mr-1 h-6 w-6 md:h-8 md:w-8"
       />
-      THE Rock:
+      THE Rock
     </h2>
-    <p class="mb-5">Determination. Determination is my driver.</p>
+    <p class="mb-5 md:mb-8">Determination. Determination is my driver.</p>
   </section>
 </template>
 <script setup lang="ts">

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -31,7 +31,7 @@
       internship, I began working full time as a Front End Developer at
       <NuxtLink
         to="https://explosion.ai/"
-        class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
+        class="text-black underline hover:text-yellow-500"
         aria-label="Read more about Explosion AI on their website"
         >Explosion AI</NuxtLink
       >

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -5,9 +5,7 @@
     >
       Journey.
     </h1>
-    <h2
-      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
-    >
+    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
       <Icon name="mdi:amplifier" />
       Musician Gone Web Dev:
     </h2>
@@ -16,9 +14,7 @@
       career, and after twisting, turning, growing and evolving, I am now a
       Front End Developer.
     </p>
-    <h2
-      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
-    >
+    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
       <Icon name="heroicons:fire-16-solid" />
       New Rock:
     </h2>
@@ -40,9 +36,7 @@
       building was ambitious and the codebase complex. It was a far cry from
       beginner friendly and my brain hurt. I absolutely loved it.
     </p>
-    <h2
-      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
-    >
+    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
       <Icon name="heroicons:bolt-20-solid" />Hard Rock:
     </h2>
     <p class="mb-5">
@@ -53,9 +47,7 @@
       with ReactJS while building a personal project with plans to transfer my
       Vue skills to learning more.
     </p>
-    <h2
-      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
-    >
+    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
       <Icon name="ph:feather-fill" />Soft Rock:
     </h2>
     <p class="mb-5">
@@ -65,9 +57,7 @@
       see all sides of a story, and use criticism as a tool to improve.
     </p>
 
-    <h2
-      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
-    >
+    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
       <Icon name="heroicons:rocket-launch-16-solid" />
       THE Rock:
     </h2>

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -1,5 +1,5 @@
 <template>
-  <section>
+  <section class="md:w-4/5 lg:w-3/5">
     <h1
       class="mb-3 flex flex-col font-besley text-3xl font-bold sm:text-5xl md:mb-8 md:text-6xl lg:mb-10 lg:text-7xl"
     >

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -29,11 +29,11 @@
       of web development as a career, I enrolled in Le Wagon’s Full-Stack
       Bootcamp, kicking off my journey. After completion and a successful
       internship, I began working full time as a Front End Developer at
-      <a
-        href="https://explosion.ai/"
+      <NuxtLink
+        to="https://explosion.ai/"
         class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
         aria-label="Read more about Explosion AI on their website"
-        >Explosion AI</a
+        >Explosion AI</NuxtLink
       >
       thriving on the exciting challenge of jumping from a non-tech career into
       the exciting world of machine learning and NLP. The SaaS app we were

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -5,8 +5,8 @@
     >
       Journey.
     </h1>
-    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
-      <Icon name="mdi:amplifier" />
+    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+      <Icon name="mdi:amplifier" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       Musician Gone Web Dev:
     </h2>
     <p class="mb-5">
@@ -14,8 +14,8 @@
       career, and after twisting, turning, growing and evolving, I am now a
       Front End Developer.
     </p>
-    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
-      <Icon name="heroicons:fire-16-solid" />
+    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+      <Icon name="heroicons:fire-16-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       New Rock:
     </h2>
     <p class="mb-5">
@@ -36,8 +36,9 @@
       building was ambitious and the codebase complex. It was a far cry from
       beginner friendly and my brain hurt. I absolutely loved it.
     </p>
-    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
-      <Icon name="heroicons:bolt-20-solid" />Hard Rock:
+    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+      <Icon name="heroicons:bolt-20-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
+      Hard Rock:
     </h2>
     <p class="mb-5">
       I’ve worked with Vue.js, Nuxt, Tailwind CSS, Typescript, CSS/HTML, Cypress
@@ -47,8 +48,9 @@
       with ReactJS while building a personal project with plans to transfer my
       Vue skills to learning more.
     </p>
-    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
-      <Icon name="ph:feather-fill" />Soft Rock:
+    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+      <Icon name="ph:feather-fill" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
+      Soft Rock:
     </h2>
     <p class="mb-5">
       I carry with me the skills I have learned along the way from my life
@@ -57,8 +59,11 @@
       see all sides of a story, and use criticism as a tool to improve.
     </p>
 
-    <h2 class="flex items-center font-besley text-2xl font-bold md:text-3xl">
-      <Icon name="heroicons:rocket-launch-16-solid" />
+    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+      <Icon
+        name="heroicons:rocket-launch-16-solid"
+        class="mr-1 h-6 w-6 md:h-8 md:w-8"
+      />
       THE Rock:
     </h2>
     <p class="mb-5">Determination. Determination is my driver.</p>

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -6,7 +6,7 @@
       Journey.
     </h1>
     <h2
-      class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
+      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
     >
       <Icon name="mdi:amplifier" />
       Musician Gone Web Dev:
@@ -17,7 +17,7 @@
       Front End Developer.
     </p>
     <h2
-      class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
+      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
     >
       <Icon name="heroicons:fire-16-solid" />
       New Rock:
@@ -41,7 +41,7 @@
       beginner friendly and my brain hurt. I absolutely loved it.
     </p>
     <h2
-      class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
+      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
     >
       <Icon name="heroicons:bolt-20-solid" />Hard Rock:
     </h2>
@@ -54,7 +54,7 @@
       Vue skills to learning more.
     </p>
     <h2
-      class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
+      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
     >
       <Icon name="ph:feather-fill" />Soft Rock:
     </h2>
@@ -66,7 +66,7 @@
     </p>
 
     <h2
-      class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
+      class="flex items-center font-besley sm:text-xl md:text-2xl lg:text-3xl"
     >
       <Icon name="heroicons:rocket-launch-16-solid" />
       THE Rock:

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -5,7 +5,9 @@
     >
       Journey.
     </h1>
-    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+    <h2
+      class="mb-1 flex items-center font-besley text-xl font-bold md:mb-2 md:text-3xl"
+    >
       <Icon name="mdi:amplifier" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       Musician Gone Web Dev
     </h2>
@@ -14,7 +16,9 @@
       career, and after twisting, turning, growing and evolving, I am now a
       Front End Developer.
     </p>
-    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+    <h2
+      class="mb-1 flex items-center font-besley text-xl font-bold md:mb-2 md:text-3xl"
+    >
       <Icon name="heroicons:fire-16-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       New Rock
     </h2>
@@ -36,7 +40,9 @@
       building was ambitious and the codebase complex. It was a far cry from
       beginner friendly and my brain hurt. I absolutely loved it.
     </p>
-    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+    <h2
+      class="mb-1 flex items-center font-besley text-xl font-bold md:mb-2 md:text-3xl"
+    >
       <Icon name="heroicons:bolt-20-solid" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       Hard Rock
     </h2>
@@ -48,7 +54,9 @@
       with ReactJS while building a personal project with plans to transfer my
       Vue skills to learning more.
     </p>
-    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+    <h2
+      class="mb-1 flex items-center font-besley text-xl font-bold md:mb-2 md:text-3xl"
+    >
       <Icon name="ph:feather-fill" class="mr-1 h-6 w-6 md:h-8 md:w-8" />
       Soft Rock
     </h2>
@@ -59,7 +67,9 @@
       see all sides of a story, and use criticism as a tool to improve.
     </p>
 
-    <h2 class="flex items-center font-besley text-xl font-bold md:text-3xl">
+    <h2
+      class="mb-1 flex items-center font-besley text-xl font-bold md:mb-2 md:text-3xl"
+    >
       <Icon
         name="heroicons:rocket-launch-16-solid"
         class="mr-1 h-6 w-6 md:h-8 md:w-8"

--- a/pages/journey.vue
+++ b/pages/journey.vue
@@ -1,12 +1,10 @@
 <template>
   <section>
-    <header>
-      <h1
-        class="mb-3 flex flex-col font-besley text-3xl font-bold sm:text-5xl md:mb-8 md:text-6xl lg:mb-10 lg:text-7xl"
-      >
-        Journey.
-      </h1>
-    </header>
+    <h1
+      class="mb-3 flex flex-col font-besley text-3xl font-bold sm:text-5xl md:mb-8 md:text-6xl lg:mb-10 lg:text-7xl"
+    >
+      Journey.
+    </h1>
     <h2
       class="flex items-center font-besley text-lg sm:text-xl md:text-2xl lg:text-3xl"
     >

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -86,9 +86,9 @@
     </article>
 
     <Card header="header">
-      <div class="flex h-full flex-col gap-5 bg-purple p-5">
+      <div class="flex h-full flex-col gap-5 p-5">
         <span
-          class="flex h-1/2 w-full items-center justify-center rounded-xl bg-white"
+          class="flex h-1/2 w-full items-center justify-center rounded-xl border bg-white"
         >
           <HeaderDetails
             class="flex h-full justify-center"
@@ -98,7 +98,7 @@
           />
         </span>
         <span
-          class="flex h-1/2 w-full items-center justify-center rounded-xl bg-white"
+          class="flex h-1/2 w-full items-center justify-center rounded-xl border bg-white"
         >
           <HeaderDetails
             class="flex h-full justify-center"
@@ -128,7 +128,7 @@
     </Card>
 
     <Card header="Percentage Bar">
-      <div class="flex h-full justify-center bg-orange-100 p-5">
+      <div class="flex h-full justify-center bg-orange-200 p-5">
         <StatsPercentageBar
           class="w-10 rounded-lg"
           :items="[
@@ -164,7 +164,7 @@
     </Card>
     <Card header="custom icons">
       <div
-        class="grid h-full grid-cols-3 gap-x-4 gap-y-3 bg-teal-600 p-5 md:gap-x-5"
+        class="grid h-full grid-cols-3 gap-x-4 gap-y-3 bg-slate-600 p-5 md:gap-x-5"
       >
         <IconsActions
           class="flex h-full w-full items-center justify-center rounded-lg bg-white p-3"

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -6,10 +6,10 @@
   </h1>
   <section class="grid gap-8 md:grid-cols-2 lg:gap-10">
     <article
-      class="w-full overflow-hidden rounded-xl bg-white p-5 shadow-3xl md:col-span-2"
+      class="w-full overflow-hidden rounded-xl bg-white p-5 md:col-span-2"
     >
       <ExplosionLogo class="mb-5 h-24 w-24" />
-      <h2 class="font-besley text-xl font-bold uppercase">Prodigy Teams</h2>
+      <h2 class="font-besley text-xl font-bold md:text-3xl">Prodigy Teams</h2>
       <div class="lg:flex lg:items-center lg:justify-between">
         <div class="mr-8 w-full">
           <p class="mb-5 pt-3">

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -8,7 +8,6 @@
     <article
       class="w-full overflow-hidden border-b bg-white pb-8 md:col-span-2 lg:pb-5"
     >
-      <ExplosionLogo class="mb-5 h-24 w-24" />
       <h2 class="mb-1 font-besley text-xl font-bold md:mb-2 md:text-3xl">
         Prodigy Teams
       </h2>

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -6,7 +6,7 @@
   </h1>
   <section class="grid gap-8 md:grid-cols-2 lg:gap-10">
     <article
-      class="w-full overflow-hidden rounded-xl bg-white p-5 md:col-span-2"
+      class="mb-5 w-full overflow-hidden rounded-xl border-b bg-white p-5 pb-5 md:col-span-2"
     >
       <ExplosionLogo class="mb-5 h-24 w-24" />
       <h2 class="font-besley text-xl font-bold md:text-3xl">Prodigy Teams</h2>

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -6,13 +6,15 @@
   </h1>
   <section class="grid gap-8 md:grid-cols-2 lg:gap-10">
     <article
-      class="mb-5 w-full overflow-hidden rounded-xl border-b bg-white p-5 pb-5 md:col-span-2"
+      class="w-full overflow-hidden border-b bg-white pb-8 md:col-span-2 lg:pb-5"
     >
       <ExplosionLogo class="mb-5 h-24 w-24" />
-      <h2 class="font-besley text-xl font-bold md:text-3xl">Prodigy Teams</h2>
+      <h2 class="mb-1 font-besley text-xl font-bold md:mb-2 md:text-3xl">
+        Prodigy Teams
+      </h2>
       <div class="lg:flex lg:items-center lg:justify-between">
         <div class="mr-8 w-full">
-          <p class="mb-5 pt-3">
+          <p class="mb-5 pt-3 md:mb-8">
             I worked as a Front End Engineer at
             <NuxtLink
               href="https://explosion.ai/"
@@ -29,7 +31,7 @@
               >Prodigy Teams</NuxtLink
             >.
           </p>
-          <p class="mb-5">
+          <p class="mb-5 md:mb-8">
             Prodigy Teams collaboratively uses their developer tool,
             <NuxtLink
               href="https://prodi.gy/"
@@ -45,7 +47,7 @@
             in tech, but I thrived on the challenge.
           </p>
 
-          <p class="mb-5">
+          <p class="mb-5 md:mb-8">
             With permission from the founders (full disclosure: it was their
             idea), as a taste of a portion of my contributions, I am showcasing
             the dashboard feature and all of its components I made for Prodigy
@@ -53,7 +55,7 @@
             for use in my portfolio to show the full code.
           </p>
 
-          <p class="mb-8">
+          <p class="mb-8 md:mb-8">
             I learned a lot from the process of getting this to look and
             function as it did in the original app, which was built desktop
             first with a very complicated backend. It was great to strip the
@@ -84,7 +86,9 @@
         </div>
       </div>
     </article>
-
+    <h2 class="font-besley text-xl font-bold md:col-span-2 md:mb-2 md:text-3xl">
+      Dashboard Components
+    </h2>
     <Card header="header">
       <div class="flex h-full flex-col gap-5 p-5">
         <span

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -14,28 +14,28 @@
         <div class="mr-8 w-full">
           <p class="mb-5 pt-3">
             I worked as a Front End Engineer at
-            <a
+            <NuxtLink
               href="https://explosion.ai/"
               target="_blank"
-              class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-              >Explosion AI</a
+              class="text-black underline hover:text-yellow-500"
+              >Explosion AI</NuxtLink
             >
             (developer tools for AI, Machine Learning and Natural Language
             Processing) on their SaaS product,
-            <a
+            <NuxtLink
               href="https://prodigy.ai/teams"
               target="_blank"
-              class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-              >Prodigy Teams</a
+              class="text-black underline hover:text-yellow-500"
+              >Prodigy Teams</NuxtLink
             >.
           </p>
           <p class="mb-5">
             Prodigy Teams collaboratively uses their developer tool,
-            <a
+            <NuxtLink
               href="https://prodi.gy/"
               target="_blank"
-              class="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-              >Prodigy</a
+              class="text-black underline hover:text-yellow-500"
+              >Prodigy</NuxtLink
             >, in the cloud, managing teams, annotators, data tasks, and running
             automated processes like model training (including LLMs), all while
             the user hosts their data on their own cluster. It was built in

--- a/pages/projects/explosion/index.vue
+++ b/pages/projects/explosion/index.vue
@@ -356,7 +356,6 @@ import IconsTrash from '~/components/icons/IconsTrash.vue'
 import IconsUserMinus from '~/components/icons/IconsUserMinus.vue'
 import IconsUserPlus from '~/components/icons/IconsUserPlus.vue'
 import IconsAnimateSparklesBlk from '~/components/icons/IconsAnimateSparklesBlk.vue'
-import ExplosionLogo from '~/components/ExplosionLogo.vue'
 
 useHead({
   title: 'Explosion Ai',


### PR DESCRIPTION
closes #89

## Journey View Design
Narrowed the paragraph width, increased global font size to `text-lg`, general padding, margins, design.  Changed all app inline links to black text, underline and yellow on hover.  

This PR blew scope a little bit in order to get the text consistent throughout the app, such as card titles, and, most notably, the Explosion view - text, card background colour changes, design tweaks. 

<img width="1090" alt="Screenshot 2024-03-09 at 23 09 14" src="https://github.com/jalridley/portfolio/assets/72085091/828287bd-ce9d-444d-a87e-cd2445a3e711">
