### PR TITLE
removed flex below lg, increased sm image size rounded-b-3xl

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <section class="flex justify-between">
+  <section class="lg:flex lg:justify-between">
     <h1
-      class="flex flex-col font-besley text-3xl font-bold sm:text-5xl md:space-y-2 md:text-6xl lg:text-7xl"
+      class="flex flex-col font-besley text-4xl font-bold xs:text-5xl md:space-y-2 md:text-6xl lg:text-7xl"
     >
       <span>Introducing</span>
       <span>Jal Ridley.</span>
@@ -11,11 +11,11 @@
     <div class="w-full">
       <NuxtImg
         src="/avatar.png"
-        class="mt-6 flex-1 rounded-b-full md:mt-10 lg:mt-14"
+        class="ml-auto mt-6 flex-1 rounded-b-3xl md:mt-10 lg:mt-14"
         alt="illustration of Jal smiling with short hair styled up"
         width="548px"
         height="566px"
-        sizes="xs:200px sm:348px md:448px lg:566px xl:566px"
+        sizes="xs:348px sm:348px md:448px lg:566px xl:566px"
         format="webp"
         decoding="auto"
         loading="lazy"


### PR DESCRIPTION
closes #97 

- removed flex below large screens
- increased small image size
- exchanged rounded-full with rounded-b-3xl

<img width="511" alt="Screenshot 2024-03-11 at 19 19 37" src="https://github.com/jalridley/portfolio/assets/72085091/829a3930-4903-4fb8-904b-c6b944838242">
